### PR TITLE
License updates

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+# Open Scriptures Hebrew Bible
+
+This work is based on *The Westminster Leningrad Codex*, which is in the public domain.
+
+# License
+
+## Creative Commons Attribution 4.0 International (CC BY 4.0)
+
+This is a human-readable summary of (and not a substitute for) the [license](http://creativecommons.org/licenses/by/4.0/).
+
+### You are free to:
+
+ * **Share** — copy and redistribute the material in any medium or format
+ * **Adapt** — remix, transform, and build upon the material
+for any purpose, even commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+### Under the following terms:
+
+ * **Attribution** — You must attribute the work as follows: "Original work of the Open Scriptures Hebrew Bible available at https://github.com/openscriptures/morphhb". You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+
+**No additional restrictions** — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+
+### Notices:
+
+You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation.
+
+No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ Lemma and morphology data are licensed under a
 [Creative Commons Attribution 4.0 International](http://creativecommons.org/licenses/by/4.0/)
 license. For attribution purposes, credit the Open Scriptures Hebrew Bible
 Project. The text of the WLC remains in the
-[Public Domain](http://creativecommons.org/publicdomain/mark/1.0/).
+[Public Domain](http://creativecommons.org/publicdomain/mark/1.0/).  See the [LICENSE](LICENSE.md) file for more information.
 
 ##	Additional Resources
 

--- a/wlc/1Chr.xml
+++ b/wlc/1Chr.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">ciro izzo</contributor>

--- a/wlc/1Kgs.xml
+++ b/wlc/1Kgs.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Daniel Bowman</contributor>
         <contributor role="ctb">Ashley Whitlatch</contributor>

--- a/wlc/1Sam.xml
+++ b/wlc/1Sam.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">M Cecil Dietz</contributor>

--- a/wlc/2Chr.xml
+++ b/wlc/2Chr.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">ralph zak</contributor>
         <contributor role="ctb">Petr Miencil</contributor>

--- a/wlc/2Kgs.xml
+++ b/wlc/2Kgs.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">ciro izzo</contributor>

--- a/wlc/2Sam.xml
+++ b/wlc/2Sam.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">Matan Bino</contributor>

--- a/wlc/Amos.xml
+++ b/wlc/Amos.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Justin So</contributor>
         <contributor role="ctb">Bryant Huang</contributor>

--- a/wlc/Dan.xml
+++ b/wlc/Dan.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Joel Ruark</contributor>
         <contributor role="ctb">Pete Myers</contributor>

--- a/wlc/Deut.xml
+++ b/wlc/Deut.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Luong Hao Tran</contributor>
         <contributor role="ctb">Andy Hubert</contributor>

--- a/wlc/Eccl.xml
+++ b/wlc/Eccl.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
       </work>
       <workPrefix path="//w/@lemma" osisWork="Strong"/>

--- a/wlc/Esth.xml
+++ b/wlc/Esth.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">Ben Dwyer</contributor>

--- a/wlc/Exod.xml
+++ b/wlc/Exod.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Ryan Davis</contributor>
         <contributor role="ctb">Andy Hubert</contributor>

--- a/wlc/Ezek.xml
+++ b/wlc/Ezek.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">David Troidl</contributor>
       </work>

--- a/wlc/Ezra.xml
+++ b/wlc/Ezra.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Daniel Bowman</contributor>
       </work>

--- a/wlc/Gen.xml
+++ b/wlc/Gen.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">David Troidl</contributor>
         <contributor role="ctb">Darrell Smith</contributor>
         <contributor role="ctb">Daniel Owens</contributor>

--- a/wlc/Hab.xml
+++ b/wlc/Hab.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
       </work>

--- a/wlc/Hag.xml
+++ b/wlc/Hag.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Eddy Yates</contributor>
       </work>

--- a/wlc/Hos.xml
+++ b/wlc/Hos.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">Daniel Bowman</contributor>

--- a/wlc/Isa.xml
+++ b/wlc/Isa.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">David Troidl</contributor>
         <contributor role="ctb">Luong Hao Tran</contributor>

--- a/wlc/Jer.xml
+++ b/wlc/Jer.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">Michael Fenn</contributor>

--- a/wlc/Job.xml
+++ b/wlc/Job.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Darrell Smith</contributor>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Luong Hao Tran</contributor>

--- a/wlc/Joel.xml
+++ b/wlc/Joel.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Joel Ruark</contributor>
         <contributor role="ctb">Andy Hubert</contributor>

--- a/wlc/Jonah.xml
+++ b/wlc/Jonah.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">David Troidl</contributor>
         <contributor role="ctb">Andy Hubert</contributor>

--- a/wlc/Josh.xml
+++ b/wlc/Josh.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">Natashia Roy</contributor>

--- a/wlc/Judg.xml
+++ b/wlc/Judg.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">Ashley Whitlatch</contributor>

--- a/wlc/Lam.xml
+++ b/wlc/Lam.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">Nathan Bierma</contributor>

--- a/wlc/Lev.xml
+++ b/wlc/Lev.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">zac rigsby</contributor>

--- a/wlc/Mal.xml
+++ b/wlc/Mal.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">Pete Myers</contributor>

--- a/wlc/Mic.xml
+++ b/wlc/Mic.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">tiago thorlby</contributor>
       </work>

--- a/wlc/Nah.xml
+++ b/wlc/Nah.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Zsolt Jarai</contributor>
       </work>

--- a/wlc/Neh.xml
+++ b/wlc/Neh.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
       </work>
       <workPrefix path="//w/@lemma" osisWork="Strong"/>

--- a/wlc/Num.xml
+++ b/wlc/Num.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">Adam Nagelvoort</contributor>

--- a/wlc/Obad.xml
+++ b/wlc/Obad.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Ryan Davis</contributor>
         <contributor role="ctb">Andy Hubert</contributor>

--- a/wlc/Prov.xml
+++ b/wlc/Prov.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">David Troidl</contributor>
         <contributor role="ctb">Andy Hubert</contributor>

--- a/wlc/Ps.xml
+++ b/wlc/Ps.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Darrell Smith</contributor>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">David Troidl</contributor>

--- a/wlc/Ruth.xml
+++ b/wlc/Ruth.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">David Troidl</contributor>
         <contributor role="ctb">Luong Hao Tran</contributor>

--- a/wlc/Song.xml
+++ b/wlc/Song.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">pete Norcross</contributor>

--- a/wlc/Zech.xml
+++ b/wlc/Zech.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Andy Hubert</contributor>
         <contributor role="ctb">libor neuman</contributor>

--- a/wlc/Zeph.xml
+++ b/wlc/Zeph.xml
@@ -66,7 +66,7 @@
         <creator role="edt">Open Scriptures Hebrew Bible Project</creator>
         <date>2017.12.10</date>
         <identifier type="URL">https://github.com/openscriptures/morphhb</identifier>
-        <rights type="x-BY-SA">Creative Commons Attribution-ShareAlike</rights>
+        <rights type="x-BY">Creative Commons Attribution 4.0</rights>
         <contributor role="ctb">Daniel Owens</contributor>
         <contributor role="ctb">Joseph Li</contributor>
       </work>


### PR DESCRIPTION
This PR fixes the license for OSHB everywhere to consistently report that it is CC BY 4.0.

@AndyHubert Take note of these changes if they affect our output files from the parsing app.