### PR TITLE
Corrected lemma in Isaiah 52:5

### DIFF
--- a/wlc/Isa.xml
+++ b/wlc/Isa.xml
@@ -14883,7 +14883,7 @@
           <w lemma="c/8548" morph="HC/Ncmsa" id="23Lmg">וְ/תָמִ֥יד</w>
           <w lemma="3605" morph="HNcmsc" id="23R4v">כָּל</w><seg type="x-maqqef">־</seg><w lemma="d/3117" n="0.0" morph="HTd/Ncmsa" id="23Ut7">הַ/יּ֖וֹם</w>
           <w lemma="8034" morph="HNcmsc/Sp1cs" id="23Xof">שְׁמִ֥/י</w>
-          <w lemma="m/5006" n="0" morph="HVrsmsa" id="235uC">מִנֹּאָֽץ</w><seg type="x-sof-pasuq">׃</seg>
+          <w lemma="5006" n="0" morph="HVrsmsa" id="235uC">מִנֹּאָֽץ</w><seg type="x-sof-pasuq">׃</seg>
         </verse>
         <verse osisID="Isa.52.6">
           <w lemma="l/3651 c" n="1.0.0" morph="HR/D" id="23EAw">לָ/כֵ֛ן</w>


### PR DESCRIPTION
From Joel Ruark:

>This looks like a function of autoparsing incorrectly assigning a lemma, because the form looks like there's a preposition there. But there's not, it's just a funky participle. The lemma should be "5006".