### PR TITLE
Correct morph parsing of שִׁלַּחְתִּ֤י in Jer 49:37

### DIFF
--- a/wlc/Jer.xml
+++ b/wlc/Jer.xml
@@ -19891,7 +19891,7 @@
           <w lemma="853" morph="HTo" id="24yWG">אֶת</w><seg type="x-maqqef">־</seg><w lemma="2740" morph="HNcmsc" id="24TAB">חֲר֥וֹן</w>
           <w lemma="639" n="1.0" morph="HNcmsc/Sp1cs" id="24TEv">אַפִּ֖/י</w>
           <w lemma="5002" morph="HNcmsc" id="24VbA">נְאֻם</w><seg type="x-maqqef">־</seg><w lemma="3068" n="1" morph="HNp" id="24XvA">יְהוָ֑ה</w>
-          <w lemma="c/7971" morph="HR/Sp3mp" id="246wV">וְ/שִׁלַּחְתִּ֤י</w>
+          <w lemma="c/7971" morph="HR/Vpp1cs" id="246wV">וְ/שִׁלַּחְתִּ֤י</w>
           <w lemma="310 a" n="0.1.0" morph="HR/Sp3mp" id="24M3D">אַֽחֲרֵי/הֶם֙</w>
           <w lemma="853" morph="HTo" id="24pCv">אֶת</w><seg type="x-maqqef">־</seg><w lemma="d/2719" n="0.1" morph="HTd/Ncfsa" id="24Wv7">הַ/חֶ֔רֶב</w>
           <w lemma="5704" morph="HR" id="24fnt">עַ֥ד</w>


### PR DESCRIPTION
In Jeremiah 49:37, the parsing is probably wrong for word שִׁלַּחְתִּ֤י with id='246wV'.

Proposing to change the morph parsing from

Sp3mp

to

Vpp1cs

Any Hebrew experts out there, please do correct me if I'm wrong.

Many thanks.

Ulrik Sandborg-Petersen
