### PR TITLE
Word correction

### DIFF
--- a/wlc/Amos.xml
+++ b/wlc/Amos.xml
@@ -1731,7 +1731,7 @@
           <w lemma="1471 a" n="1" morph="HNcmsa" id="30id4">גּ֑וֹי</w>
           <w lemma="c/3905" morph="HC/Vqq3cp" id="30rbK">וְ/לָחֲצ֥וּ</w>
           <w lemma="853" n="0.0.0" morph="HTo/Sp2mp" id="30fQG">אֶתְ/כֶ֛ם</w>
-          <w lemma="m/l/935" morph="HR/Np" id="30HAz">מִ/לְּב֥וֹא</w>
+          <w lemma="m/l/935" morph="HR/Np" id="30HAz">מִ/לְּ/ב֥וֹא</w>
           <w lemma="2574" n="0.0" morph="HNp" id="30J4B">חֲמָ֖ת</w>
           <w lemma="5704" morph="HR" id="30cc4">עַד</w><seg type="x-maqqef">־</seg><w lemma="5158 a" morph="HNcmsc" id="30oRq">נַ֥חַל</w>
           <w lemma="d/6160" n="0" morph="HTd/Ncfsa" id="30cUw">הָ/עֲרָבָֽה</w><seg type="x-sof-pasuq">׃</seg>


### PR DESCRIPTION
In Amos 6:14, מִ/לְּב֥וֹא doesn't fit the syntax. I changed it to מִ/לְּ/ב֥וֹא.

