### PR TITLE
Add linking capability (to Read app)

### DIFF
--- a/read/Script/Read.js
+++ b/read/Script/Read.js
@@ -1,6 +1,7 @@
 /**
  * @fileOverview Read is the JavaScript controller for OSHB Read.
- * @version 1.0
+ * @version 1.1
+ * Version 1.1: Factored in Reference Location, to link to the current verse (marcstober).
  * @author David
  */
 (function() {
@@ -9,7 +10,8 @@
         "book": document.getElementById('book'),
         "chapter": document.getElementById('chapter'),
         "verse": document.getElementById('verse'),
-        "display": document.getElementById('display')
+        "display": document.getElementById('display'),
+        "link": document.getElementById('link')
     };
 // Utility functions.
     // Utility function to clear child nodes from an element.
@@ -74,7 +76,9 @@
         for (; i <= num; i++) {
             elements.verse.options[elements.verse.options.length] = new Option(i);
         }
-		getChapter();
+        elements.verse[initialVerse].selected = "selected";
+        initialVerse = 0; 
+        getChapter();
     };
     // Extracts the XML chapter from bookText.
     var setChapterFile = function() {
@@ -93,6 +97,11 @@
         return loadFile("../wlc/" + book + ".xml", setChapters);
 	};
 // Interface elements.
+    // Marks up the link.
+	function linkMark() {
+		var address = refLocation.getLocation(elements.book.value, elements.chapter.value, elements.verse.value);
+		return '<a href="' + address + '">' + address + '</a>'
+	}
 	var chapterMarkup = window.chapterMarkup;
     // Marks up the chapter.
 	function getChapter() {
@@ -101,14 +110,18 @@
 		elements.display.appendChild(chapterMarkup(chapter));
 		// Highlight the selected verse.
 		selectVerse(document.getElementById("v." + elements.verse.value));
+        elements.link.innerHTML = linkMark();
 	}
     // Initialize.
-    var initialChapter = elements.chapter.value - 1,
+    var refLocation = window.refLocation,
+		initialChapter = refLocation.chapterIndex(),
+		initialVerse = refLocation.verseIndex(),
 		selectVerse = window.selectVerse;
     elements.book.onchange = setBookFile;
     elements.chapter.onchange = setChapterFile;
     elements.verse.onchange = function() {
 		selectVerse(document.getElementById("v." + elements.verse.value));
+        elements.link.innerHTML = linkMark();
 	};
     setBookFile();
 })();

--- a/read/Script/ReferenceLocation.js
+++ b/read/Script/ReferenceLocation.js
@@ -1,0 +1,57 @@
+/**
+ * @fileOverview Reference Location manages URL locations.
+ * @version 1.0
+ * @author David
+ */
+refLocation = function() {
+	// Assemble an array of SBL book abbreviations.
+	var book = document.getElementById("book"),
+		sblNames = [], i = 0;
+	while (book.options[i]) {
+		sblNames.push(book.options[i].value);
+		i++;
+	}
+	// Parses the URL.
+	function parseURL() {
+		var parts = {book: "Gen", chapter: 1, verse: 1},
+			url = window.location,
+			results;
+		if (url.length > 75) {return parts;} // Excessively long URL.
+		results = url.search.match(/b=(\w+)/);
+		if (results && results[1]) {
+			if (sblNames.indexOf(results[1]) >= 0) {
+				parts.book = results[1];
+			} else {
+				mtNum = parseInt(results[1]);
+				if (mtNum > 0 && mtNum < 40) {
+					parts.book = sblNames[mtNum - 1];
+				} else {
+					return parts; // Unknown book number.
+				}
+			}
+		} else {
+			return parts; // Unknown book abbreviation.
+		}
+		results = url.search.match(/c=(\d+)/);
+		if (results) {parts.chapter = parseInt(results[1]);}
+		results = url.search.match(/v=(\d+)/);
+		if (results) {parts.verse = parseInt(results[1]);}
+		return parts;
+	}
+	// Apply the results.
+	var ref = parseURL(),
+		homePage = window.location.protocol + "//" + window.location.host + "/read/index.html";
+	book[sblNames.indexOf(ref.book)].selected = "selected";
+	// Return the public interface.
+	return {
+		chapterIndex: function() {
+			return ref.chapter - 1;
+		},
+		verseIndex: function() {
+			return ref.verse - 1;
+		},
+		getLocation: function(sblBook, chapter, verse) {
+			return homePage + "?b=" + sblBook + "&c=" + chapter + "&v=" + verse;
+		}
+	}
+}();

--- a/read/Style/ReadStyle.css
+++ b/read/Style/ReadStyle.css
@@ -59,6 +59,16 @@ section#work
 {
 	margin: 0.5em;
 }
+section#work aside
+{
+    padding: 0 1em 0.5em 1em;
+    background-color: rgba(255, 251, 208, 0.7);
+    border: 3px double #217438;
+    width: intrinsic;           /* Safari/WebKit uses a non-standard name */
+    width: -moz-max-content;    /* Firefox/Gecko */
+    width: -webkit-max-content; /* Chrome */
+    margin-top: 0.5em;
+}
 /* Passage Styles */
 section.passage
 {

--- a/read/index.html
+++ b/read/index.html
@@ -14,7 +14,6 @@
             <form>
                 <label for="book">Book</label>
                 <select id="book">
-					<!-- Haggai selected for testing. -->
                     <option value="Gen">Genesis</option>
                     <option value="Exod">Exodus</option>
                     <option value="Lev">Leviticus</option>
@@ -38,7 +37,7 @@
                     <option value="Nah">Nahum</option>
                     <option value="Hab">Habakkuk</option>
                     <option value="Zeph">Zephaniah</option>
-                    <option value="Hag" selected="selected">Haggai</option>
+                    <option value="Hag">Haggai</option>
                     <option value="Zech">Zechariah</option>
                     <option value="Mal">Malachi</option>
                     <option value="Ps">Psalms</option>
@@ -71,7 +70,13 @@
                 <h2>Chapter Display</h2>
             </section>
 			<section id="morphDisplay" title="Morphology Display"></section>
-        </section>
+			<aside>
+				<p><strong>Link to this verse:</strong><br />
+				<code><span id="link"></span></code><br />
+				(<em>Right-click</em> on the link, and Copy.<br />
+				You can paste the link into an email, or make a bookmark for it.)</p>
+			</aside>
+        </section>        
         <div class="footer">
             Read is part of the
             <a href="https://openscriptures.github.io/morphhb/index.html">Open Scriptures Hebrew Bible</a> project.<br/>
@@ -79,6 +84,7 @@
             <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img
                alt="Creative Commons License" style="border-width:0; margin:0.3ex" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a>
         </div>
+        <script src="Script/ReferenceLocation.js"></script>
         <script src="Script/MorphologyParser.js"></script>
         <script src="Script/ClickWord.js"></script>
         <script src="Script/SelectVerse.js"></script>

--- a/read/readme.md
+++ b/read/readme.md
@@ -26,6 +26,9 @@ Several components have been adapted from
 [OSHB Verse](https://hb.openscriptures.org/structure/OshbVerse/),
 we have:
 
+-	ReferenceLocation.js (Added 4/19/2024) manages URL locations, to
+	make and process the link.
+	
 -	AccentCatalog.js catalogs the accents by type and scope.
 
 -	Books.js records book data for navigation.
@@ -69,6 +72,7 @@ OSHB Read is licensed under a
 license. For attribution purposes, credit the Open Scriptures Hebrew Bible
 Project.
 
+Updated April 19, 2024 (marcstober)
 Updated September 18, 2019  
 Updated August 30, 2019  
 Updated July 27, 2019  


### PR DESCRIPTION
**This adds linking capability to the Read app, in the same way it already works in the Verse app.**

I attempted to match the Verse app as much as possible. This adds some duplicated code between the Read and Verse apps, but that seemed to already be the approach used to maintain these two apps. There are some other things I might have done differently if making this from scratch (like updating `window.location` automatically when a user changes the drop-down value, or using `let`/`const` in new development) but my goal here was to be consistent with the existing Verse app with minimal other changes.

The one change a user would notice (besides the new functionality) is that the read app no longer opens by default to Haggai, but to Genesis. There was a comment (I removed) that opening by default to Haggai was for testing, and I thought it made sense to match the functionality of Verse app (which defaults to Genesis).